### PR TITLE
Deep paths in slugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ var mongoose          = require('mongoose'),
       slugs           = require('slugs');
 
 function slugify(model, options){
-    var slugParts = _.values(_.pick(model, options.source));
+    var slugParts = _.map(options.source, function(path) {
+        return _.get(model, path);
+    });
     return slugs(slugParts.join(' '));
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mrphelz/slugin",
   "dependencies": {
     "inflection": "^1.7.0",
-    "lodash": "^3.6.0",
+    "lodash": "^3.7.0",
     "mongoose": "^4.0.1",
     "slugs": "^0.1.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,13 +3,17 @@ var
     should   = require('should'),
     _        = require('lodash'),
     Car      = require('./car'),
-    Kitten   = require('./kitten');
+    Kitten   = require('./kitten'),
+    Person   = require('./person');
 mongoose.connect('mongodb://localhost:27017/spike');
 
 function setup(done){
     Kitten.remove(function(e){
         if(e) return done(e);
-        Car.remove(done);
+        Car.remove(function(e) {
+            if(e) return done(e);
+            Person.remove(done);
+        });
     });
 }
 
@@ -113,6 +117,28 @@ describe('Slugin', function(){
             it('should allow the same model name for each without bumping the iterator', function(){
                 var scot = _.find(cars, {make:'Scottish'});
                 scot.slug.should.eql('scottish-highlander');
+            });
+        });
+    });
+
+    describe('When saving a single person with a deep path slug source', function(){
+        before(setup);
+
+        before(function(done){
+            var someGuy = new Person({
+                name : {
+                    first: 'Some',
+                    last: 'Guy'
+                }
+            });
+            someGuy.save(done);
+        });
+
+        it('Should save the person to the database with a slug based on the name object paths', function(done){
+            Person.findOne({slug_base : 'some-guy'}, function(e,k){
+                (e===null).should.be.true;
+                k.slug.should.eql('some-guy');
+                done();
             });
         });
     });

--- a/test/person.js
+++ b/test/person.js
@@ -1,0 +1,14 @@
+var mongoose = require('mongoose')
+var slugin         = require('../');
+
+var personSchema = mongoose.Schema(
+	{ 
+		name: {
+			first: String,
+			last: String
+		}
+	});
+
+personSchema.plugin(slugin, {source: ['name.first', 'name.last']});
+
+module.exports = mongoose.model('Person', personSchema);


### PR DESCRIPTION
lodash 3.7.0 added support for deep paths, working with properties in nested objects. We can use this here to support slugin paths in nested objects such as:

```
var personSchema = mongoose.Schema(
    { 
        name: {
            first: String,
            last: String
        }
    });

personSchema.plugin(slugin, {source: ['name.first', 'name.last']});
```

This pull request updates lodash from 3.6.0 to 3.7.0 to support this feature as well as modifies the method that selects the parts of the object to use for the slug.

I have also added a unit test for this feature.
